### PR TITLE
Skip cert verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,21 @@ ret, err := verifier.Verify(urlToCheck)
 ...
 ```
 
+## Skip HTTPS certificate verification
+
+By default, the library will verify the HTTPS certificate of the URL. To skip the verification, call `verifier.SkipHTTPSCertificateVerification()`:
+
+```go
+urlToCheck := "https://example.com"
+
+verifier := NewVerifier()
+verifier.EnableHTTPCheck()
+// Danger: Makes SSRF easier!
+verifier.AllowSkipCertVerification()
+ret, err := verifier.Verify(urlToCheck)
+...
+```
+
 ## Credits
 
 This library is heavily inspired by

--- a/http_check.go
+++ b/http_check.go
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: MIT
 package urlverifier
 
-import "net/http"
+import (
+	"crypto/tls"
+	"net/http"
+)
 
 // HTTP is the result of a HTTP check
 type HTTP struct {
@@ -17,8 +20,19 @@ func (v *Verifier) CheckHTTP(urlToCheck string) (*HTTP, error) {
 		IsSuccess: false,
 	}
 
+	// Create client for skipping certificate verification
+	var client http.Client
+
+	if v.skipCertVerification {
+		client = http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			},
+		}
+	}
+
 	// Check if the URL is reachable via HTTP
-	resp, err := http.Get(urlToCheck)
+	resp, err := client.Get(urlToCheck)
 	if err != nil {
 		return &ret, err
 	}

--- a/http_check_test.go
+++ b/http_check_test.go
@@ -69,7 +69,7 @@ func TestCheckHTTP_expiredCert(t *testing.T) {
 
 	assert.Equal(t, expected, ret)
 	assert.IsType(t, &url.Error{}, err)
-	assert.ErrorContains(t, err, "failed to verify certificate")
+	assert.ErrorContains(t, err, "x509:")
 }
 
 func TestCheckHTTP_expiredCert_allowSkip(t *testing.T) {

--- a/http_check_test.go
+++ b/http_check_test.go
@@ -55,3 +55,36 @@ func TestCheckHTTP_Unreachable(t *testing.T) {
 	assert.IsType(t, &url.Error{}, err)
 	assert.ErrorContains(t, err, "lookup example.unreachable: no such host")
 }
+
+func TestCheckHTTP_expiredCert(t *testing.T) {
+	urlToCheck := "https://self-signed.badssl.com/"
+
+	verifier := NewVerifier()
+	ret, err := verifier.CheckHTTP(urlToCheck)
+
+	expected := &HTTP{
+		Reachable: false,
+		IsSuccess: false,
+	}
+
+	assert.Equal(t, expected, ret)
+	assert.IsType(t, &url.Error{}, err)
+	assert.ErrorContains(t, err, "failed to verify certificate")
+}
+
+func TestCheckHTTP_expiredCert_allowSkip(t *testing.T) {
+	urlToCheck := "https://self-signed.badssl.com/"
+
+	verifier := NewVerifier()
+	verifier.AllowSkipCertVerification()
+	ret, err := verifier.CheckHTTP(urlToCheck)
+
+	expected := &HTTP{
+		Reachable:  true,
+		StatusCode: 200,
+		IsSuccess:  true,
+	}
+
+	assert.Equal(t, expected, ret)
+	assert.Nil(t, err)
+}

--- a/verifier.go
+++ b/verifier.go
@@ -16,6 +16,7 @@ import (
 type Verifier struct {
 	httpCheckEnabled       bool // Whether to check if the URL is reachable via HTTP (default: false)
 	allowHttpCheckInternal bool // Whether to allow HTTP checks to hosts that resolve to internal IPs (default: false)
+	skipCertVerification   bool // Whether to skip certificate verification when checking HTTP (default: false)
 }
 
 // Result is the result of a URL verification
@@ -30,7 +31,7 @@ type Result struct {
 
 // NewVerifier creates a new URL Verifier
 func NewVerifier() *Verifier {
-	return &Verifier{allowHttpCheckInternal: false}
+	return &Verifier{allowHttpCheckInternal: false, skipCertVerification: false}
 }
 
 // Verify verifies a URL. It checks if the URL is valid, parses it if so, and
@@ -141,4 +142,14 @@ func (v *Verifier) AllowHTTPCheckInternal() {
 // DisallowHTTPCheckInternal disallows checking internal URLs
 func (v *Verifier) DisallowHTTPCheckInternal() {
 	v.allowHttpCheckInternal = false
+}
+
+// AllowSkipCertVerification skips certificate verification when checking HTTPS
+func (v *Verifier) AllowSkipCertVerification() {
+	v.skipCertVerification = true
+}
+
+// DisallowSkipCertVerification does not skip certificate verification when checking HTTPS
+func (v *Verifier) DisallowSkipCertVerification() {
+	v.skipCertVerification = false
 }


### PR DESCRIPTION
In some cases, we need to verify the url even if the HTTPS certificate is not valid.
This change gives the opportunity to skip the certificate validation.